### PR TITLE
Type checker

### DIFF
--- a/listeners/structureBuilder.py
+++ b/listeners/structureBuilder.py
@@ -86,11 +86,11 @@ class structureBuilder(coolListener):
         if len(parameters) == 0 :
             newMethod = Method(return_type)
         else:
-            print("Method with params", parameters)
             newMethod = Method(return_type, parameters)
         
         ctx.activeClass.addMethod(name, newMethod)
 
+        # Job of typeChecker now:
         # Add parameter type bindings in the object scope
         # ctx.objectEnv.openScope()
         # for id, type in parameters:

--- a/listeners/structureBuilder.py
+++ b/listeners/structureBuilder.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from ctypes import util
 from pprint import pprint
 from antlr.coolListener import coolListener
@@ -9,29 +10,20 @@ from util.structure import _allClasses as classDict
 from antlr4.tree.Tree import ParseTree
 # Expression node's can store a .dataType attribute for their "runtime evaluation" type. This is compared to the stated type.
 
-def getCurrentScope(ctx: ParseTree) -> SymbolTableWithScopes:
-    p = ctx.parentCtx
-    while (p and not hasattr(p, 'objectEnv') and not hasattr(p, 'activeClass')):
-        p = p.parentCtx
-    
-    return p.objectEnv, p.activeClass
-
-valid_self_type_returns = ["SELF_TYPE", "self"]
 
 class structureBuilder(coolListener):
-
-
-    
-    objectClass = Klass("Object", None)
-    setBaseKlasses()
-
+    '''
+    Responsible for adding all classes to the _allClasses global dictionary.
+    We do this before we begin type-checking
+    '''
     basicTypes = set(['Int','String','Bool'])
 
     def __init__(self) -> None:
         classDict.clear()          
-        Klass("Object", None)
-        setBaseKlasses()  # Int, Bool, String, IO
+        setBaseKlasses() 
 
+    def getDefinedClasses():
+        return deepcopy(classDict)
     
     def enterKlass(self, ctx: coolParser.KlassContext):
        
@@ -53,201 +45,3 @@ class structureBuilder(coolListener):
 
         else:            
             k = Klass(name=name)
-
-        objectEnv = SymbolTableWithScopes(k)  # Object environment in a class
-
-        for feature in ctx.feature():  # children nodes should know the class and Object environment
-            feature.activeClass = k
-            feature.objectEnv = objectEnv
-
-
-    def enterFeature_function(self, ctx: coolParser.Feature_functionContext):
-        name = ctx.ID().getText()
-
-        parameters = []
-        names = []
-
-        for param in ctx.params:
-            if param.ID().getText() in names:
-                raise dupformals()
-            names.append(param.ID().getText())
-            parameters.append((param.ID().getText(), param.TYPE().getText()))
-        
-        return_type = ctx.TYPE().getText()
-
-        if (return_type == "SELF_TYPE"):
-            checkClass = ctx.expr().TYPE().getText()
-            if checkClass not in valid_self_type_returns:
-                raise selftypebadreturn()
-
-        if (return_type != "SELF_TYPE"):
-            try:
-                lookupClass(return_type)
-            except KeyError:
-            
-                raise returntypenoexist()
-
-        if len(parameters) == 0 :
-            newMethod = Method(return_type)
-        else:
-            newMethod = Method(return_type, parameters)
-        
-        ctx.activeClass.addMethod(name, newMethod)
-
-        # Add parameter type bindings in the object scope
-        ctx.objectEnv.openScope()
-        for id, type in parameters:
-            ctx.objectEnv[id] = type
-
-        body = ctx.expr()
-        print("Body of method <", body.getText(),'>')
-        body.objectEnv = ctx.objectEnv
-        body.activeClass = ctx.activeClass
-
-    def exitFeature_function(self, ctx:coolParser.Feature_functionContext):
-        ctx.objectEnv.closeScope() # remove parameter bindings on exit
-
-
-    def enterFeature_attribute(self, ctx: coolParser.Feature_attributeContext):
-        name = ctx.ID().getText()
-        type = ctx.TYPE().getText()
-        ctx.activeClass.addAttribute(name, type)  # we can call lookupAttribute later
-
-
-    def enterCase_expr(self, ctx: coolParser.Case_exprContext):
-        cases = ctx.case_stat()
-        present_types = []
-
-        for case in cases:
-            case_type = case.TYPE().getText()
-            if case_type in present_types:
-                raise caseidenticalbranch()
-            present_types.append(case_type)
-
-    def exitPrimary_expr(self, ctx:coolParser.Primary_exprContext):
-         # Has a single Primary child node. fetch its dataType and pass on to parent
-        primary = ctx.getChild(0)
-        try:
-            ctx.dataType = primary.dataType
-        except AttributeError:
-            print(primary.__dict__)
-            print(f"Primary expression {ctx.getText()} has no datatype")
-
-    def enterPrimary(self, ctx: coolParser.PrimaryContext):
-        if ctx.INTEGER():
-            ctx.dataType = 'Int'
-        elif ctx.STRING():
-            ctx.dataType = 'String'
-        elif ctx.TRUE() or ctx.FALSE():
-            ctx.dataType = 'Bool'
-        elif ctx.ID():  # is a variable name, assign type from scope
-            objectEnv, activeClass = getCurrentScope(ctx)
-
-            # Look for variable in this scope, if it doesn't exist, raise out of scope exception
-            try :
-                ctx.dataType = objectEnv[ctx.ID().getText()]
-            except KeyError:
-                raise outofscope()
-            
-
-        else:
-            # is a subexpression, implement type checking for generic expressions
-            pass
-
-    def exitEquals(self, ctx: coolParser.EqualsContext):
-        typeOne = ctx.children[0].dataType
-        typeTwo = ctx.children[2].dataType
-
-        if typeOne in self.basicTypes and typeTwo in self.basicTypes:
-            if typeOne != typeTwo:
-                if typeOne == "Int" and typeTwo == "String":
-                    raise badequalitytest()
-                if typeOne == "Int" and typeTwo == "Bool":
-                    raise badequalitytest2()
-                else:
-                    raise badequalitytest()  # any type discrepancy should throw error
-    
-    def exitDispatch(self, ctx:coolParser.DispatchContext):
-        # Check validity of the dispatch: method must be defined, types must conform
-        caller = ctx.getChild(0).dataType # get type of calling expression
-        k = lookupClass(caller)
-        
-        print("calling object <",caller,">")
-        methodName = ctx.ID().getText()
-        print("method name", methodName)
-        try:
-            method = k.lookupMethod(methodName)
-            # then compare formal params
-        except KeyError:
-            if caller == 'Int':
-                raise badwhilebody()
-            else: 
-                raise baddispatch(f"{caller} object does not have method '{methodName}'")
-
-    def exitAddition(self, ctx: coolParser.AdditionContext):
-        left_type = ctx.expr(0).dataType
-        right_type = ctx.expr(1).dataType
-
-        if left_type != "Int" or right_type != "Int":
-            raise badarith()
-
-    def exitSubtraction(self, ctx: coolParser.SubtractionContext):
-        left_type = ctx.expr(0).dataType
-        right_type = ctx.expr(1).dataType
-
-        if left_type != "Int" or right_type != "Int":
-            raise badarith()
-    
-    def exitDivision(self, ctx: coolParser.DivisionContext):
-        left_type = ctx.expr(0).dataType
-        right_type = ctx.expr(1).dataType
-
-        if left_type != "Int" or right_type != "Int":
-            raise badarith()
-    
-    def exitMultiplication(self, ctx: coolParser.MultiplicationContext):
-        left_type = ctx.expr(0).dataType
-        right_type = ctx.expr(1).dataType
-
-        if left_type != "Int" or right_type != "Int":
-            raise badarith()
-
-    def exitWhile(self, ctx:coolParser.WhileContext):
-        # all subexpressions of while have been evaluated.
-
-        # check that condition evaluates to a boolean
-        predicate = ctx.expr()[0]
-        if predicate.dataType != 'Bool':
-            raise badwhilecond("While predicate must evaluate to a Bool value")
-        
-    def enterLet_expr(self, ctx:coolParser.Let_exprContext):
-        # Parent node to Let_decl
-        object_env, active_class = getCurrentScope(ctx)
-        object_env.openScope()
-        body = ctx.expr()
-
-    def exitLet_expr(self, ctx: coolParser.Let_exprContext):
-        object_env, active_class = getCurrentScope(ctx)
-        object_env.closeScope()
-
-    def enterLet_decl(self, ctx:coolParser.Let_declContext):
-        # Store the variable in current Scope
-        objectEnv, activeClass = getCurrentScope(ctx)
-        objectEnv[ctx.ID().getText()] = ctx.TYPE().getText()
-
-    def enterNew(self, ctx:coolParser.NewContext):
-        # Store the TYPE and return it to parent
-        ctx.dataType == ctx.TYPE()
-
-    def exitAssignment(self, ctx:coolParser.AssignmentContext):
-        # receive the dataType from the child node
-        value = ctx.expr().dataType
-        variable = ctx.ID().getText()
-
-        # value tiene que ser un hijo o una instancia de value,
-        # es decir, value must conform to variable
-        try:
-            lookupClass(value).conformsTo(lookupClass(variable))
-        except:
-            raise assignnoconform()
-

--- a/listeners/typeChecker.py
+++ b/listeners/typeChecker.py
@@ -1,0 +1,244 @@
+from antlr.coolListener import coolListener
+from antlr.coolParser import coolParser
+
+from util.exceptions import assignnoconform, badarith, baddispatch, badwhilebody, badwhilecond, caseidenticalbranch, dupformals, missingclass, outofscope, redefinedclass, returntypenoexist, selftypebadreturn, badequalitytest, badequalitytest2
+from util.structure import *
+from antlr4.tree.Tree import ParseTree
+from util.structure import _allClasses as classDict
+
+# Expression node's can store a .dataType attribute for their "runtime evaluation" type. This is compared to the stated type.
+
+def getCurrentScope(ctx: ParseTree) -> SymbolTableWithScopes:
+    p = ctx.parentCtx
+    while (p and not hasattr(p, 'objectEnv') and not hasattr(p, 'activeClass')):
+        p = p.parentCtx
+    
+    return p.objectEnv, p.activeClass
+
+valid_self_type_returns = ["SELF_TYPE", "self"]
+
+class typeChecker(coolListener):
+    '''
+    This listener should be instantiated AFTER structureBuilder.
+    It assumes all classes in the program are in the classDict dictionary.
+    '''
+
+    basicTypes = set(['Int','String','Bool'])
+
+    def __init__(self) -> None:
+        print("Classes of Program")
+        print(list(classDict.keys()))
+        
+    def enterKlass(self, ctx: coolParser.KlassContext):
+       
+        name = ctx.TYPE(0).getText()
+        k = lookupClass(name)
+
+        objectEnv = SymbolTableWithScopes(k)  # Object environment in a class
+
+        for feature in ctx.feature():  # children nodes should know the class and Object environment
+            feature.activeClass = k
+            feature.objectEnv = objectEnv
+
+    def enterFeature_function(self, ctx: coolParser.Feature_functionContext):
+        name = ctx.ID().getText()
+
+        parameters = []
+        names = []
+
+        for param in ctx.params:
+            if param.ID().getText() in names:
+                raise dupformals()
+            names.append(param.ID().getText())
+            parameters.append((param.ID().getText(), param.TYPE().getText()))
+        
+        return_type = ctx.TYPE().getText()
+
+        if (return_type == "SELF_TYPE"):
+            checkClass = ctx.expr().TYPE().getText()
+            if checkClass not in valid_self_type_returns:
+                raise selftypebadreturn()
+
+        if (return_type != "SELF_TYPE"):
+            try:
+                lookupClass(return_type)
+            except KeyError:
+            
+                raise returntypenoexist()
+
+        if len(parameters) == 0 :
+            newMethod = Method(return_type)
+        else:
+            newMethod = Method(return_type, parameters)
+        
+        ctx.activeClass.addMethod(name, newMethod)
+
+        # Add parameter type bindings in the object scope
+        ctx.objectEnv.openScope()
+        for id, type in parameters:
+            ctx.objectEnv[id] = type
+
+        body = ctx.expr()
+        print("Body of method <", body.getText(),'>')
+        body.objectEnv = ctx.objectEnv
+        body.activeClass = ctx.activeClass
+
+    def exitFeature_function(self, ctx:coolParser.Feature_functionContext):
+        ctx.objectEnv.closeScope() # remove parameter bindings on exit
+
+
+    def enterFeature_attribute(self, ctx: coolParser.Feature_attributeContext):
+        name = ctx.ID().getText()
+        type = ctx.TYPE().getText()
+        ctx.activeClass.addAttribute(name, type)  # we can call lookupAttribute later
+
+
+    def enterCase_expr(self, ctx: coolParser.Case_exprContext):
+        cases = ctx.case_stat()
+        present_types = []
+
+        for case in cases:
+            case_type = case.TYPE().getText()
+            if case_type in present_types:
+                raise caseidenticalbranch()
+            present_types.append(case_type)
+
+    def exitPrimary_expr(self, ctx:coolParser.Primary_exprContext):
+         # Has a single Primary child node. fetch its dataType and pass on to parent
+        primary = ctx.getChild(0)
+        try:
+            ctx.dataType = primary.dataType
+        except AttributeError:
+            print(primary.__dict__)
+            print(f"Primary expression {ctx.getText()} has no datatype")
+
+    def enterPrimary(self, ctx: coolParser.PrimaryContext):
+        if ctx.INTEGER():
+            ctx.dataType = 'Int'
+        elif ctx.STRING():
+            ctx.dataType = 'String'
+        elif ctx.TRUE() or ctx.FALSE():
+            ctx.dataType = 'Bool'
+        elif ctx.ID():  # is a variable name, assign type from scope
+            objectEnv, activeClass = getCurrentScope(ctx)
+
+            # Look for variable in this scope, if it doesn't exist, raise out of scope exception
+            try :
+                ctx.dataType = objectEnv[ctx.ID().getText()]
+            except KeyError:
+                raise outofscope()
+            
+
+        else:
+            # is a subexpression, implement type checking for generic expressions
+            pass
+
+    def exitEquals(self, ctx: coolParser.EqualsContext):
+        typeOne = ctx.children[0].dataType
+        typeTwo = ctx.children[2].dataType
+
+        if typeOne in self.basicTypes and typeTwo in self.basicTypes:
+            if typeOne != typeTwo:
+                if typeOne == "Int" and typeTwo == "String":
+                    raise badequalitytest()
+                if typeOne == "Int" and typeTwo == "Bool":
+                    raise badequalitytest2()
+                else:
+                    raise badequalitytest()  # any type discrepancy should throw error
+    
+    def exitDispatch(self, ctx:coolParser.DispatchContext):
+        # Check validity of the dispatch: method must be defined, types must conform
+        caller = ctx.getChild(0).dataType # get type of calling expression
+        k = lookupClass(caller)
+        
+        print("calling object <",caller,">")
+        methodName = ctx.ID().getText()
+        print("method name", methodName)
+        try:
+            method = k.lookupMethod(methodName)
+            # then compare formal params
+        except KeyError:
+            if caller == 'Int':
+                raise badwhilebody()
+            else: 
+                raise baddispatch(f"{caller} object does not have method '{methodName}'")
+
+    def exitAddition(self, ctx: coolParser.AdditionContext):
+        left_type = ctx.expr(0).dataType
+        right_type = ctx.expr(1).dataType
+
+        if left_type != "Int" or right_type != "Int":
+            raise badarith()
+
+    def exitSubtraction(self, ctx: coolParser.SubtractionContext):
+        left_type = ctx.expr(0).dataType
+        right_type = ctx.expr(1).dataType
+
+        if left_type != "Int" or right_type != "Int":
+            raise badarith()
+    
+    def exitDivision(self, ctx: coolParser.DivisionContext):
+        left_type = ctx.expr(0).dataType
+        right_type = ctx.expr(1).dataType
+
+        if left_type != "Int" or right_type != "Int":
+            raise badarith()
+    
+    def exitMultiplication(self, ctx: coolParser.MultiplicationContext):
+        left_type = ctx.expr(0).dataType
+        right_type = ctx.expr(1).dataType
+
+        if left_type != "Int" or right_type != "Int":
+            raise badarith()
+
+    def exitWhile(self, ctx:coolParser.WhileContext):
+        # all subexpressions of while have been evaluated.
+
+        # check that condition evaluates to a boolean
+        predicate = ctx.expr()[0]
+        if predicate.dataType != 'Bool':
+            raise badwhilecond("While predicate must evaluate to a Bool value")
+        
+    def enterLet_expr(self, ctx:coolParser.Let_exprContext):
+        # Parent node to Let_decl
+        object_env, active_class = getCurrentScope(ctx)
+        object_env.openScope()
+        body = ctx.expr()
+
+    def exitLet_expr(self, ctx: coolParser.Let_exprContext):
+        object_env, active_class = getCurrentScope(ctx)
+        object_env.closeScope()
+
+    def enterLet_decl(self, ctx:coolParser.Let_declContext):
+        # Store the variable in current Scope
+        objectEnv, activeClass = getCurrentScope(ctx)
+        objectEnv[ctx.ID().getText()] = ctx.TYPE().getText()
+
+    def enterNew(self, ctx:coolParser.NewContext):
+        # Store the TYPE and return it to parent
+        ctx.dataType = ctx.TYPE().getText()
+
+    def exitAssignment(self, ctx:coolParser.AssignmentContext):
+        # receive the dataType from the child node
+        objectEnv, _ = getCurrentScope(ctx)
+        id = ctx.ID().getText()
+        leftSide = objectEnv[id]
+        rightSide = ctx.expr().dataType
+
+        try:
+            rightKlass = lookupClass(rightSide)
+            leftKlass = lookupClass(leftSide)
+        except Exception as e:
+            print(e)
+            missing = []
+            existing = classDict.keys()
+            if rightSide not in existing:
+                missing += [rightSide]
+            if leftSide not in existing:
+                missing += [leftSide]
+            msg = ','.join(missing)
+            raise missingclass(msg)
+
+        # rightSide must conform to leftSide        
+        if not rightKlass.conformsTo(leftKlass):
+            raise assignnoconform

--- a/listeners/typeChecker.py
+++ b/listeners/typeChecker.py
@@ -4,7 +4,7 @@ from importlib_metadata import Pair
 from antlr.coolListener import coolListener
 from antlr.coolParser import coolParser
 
-from util.exceptions import assignnoconform, badarith, baddispatch, badwhilebody, badwhilecond, caseidenticalbranch, dupformals, missingclass, outofscope, redefinedclass, returntypenoexist, selftypebadreturn, badequalitytest, badequalitytest2
+from util.exceptions import assignnoconform, badargs1, badarith, baddispatch, badwhilebody, badwhilecond, caseidenticalbranch, dupformals, missingclass, outofscope, redefinedclass, returntypenoexist, selftypebadreturn, badequalitytest, badequalitytest2
 from util.structure import *
 from antlr4.tree.Tree import ParseTree
 from util.structure import _allClasses as classDict
@@ -148,7 +148,16 @@ class typeChecker(coolListener):
             else: 
                 raise baddispatch(f"{caller} object does not have method '{methodName}'")
         
+        if len(ctx.params) != len(method.params):
+            raise Exception(f"Bad call to {methodName}: {len(ctx.params)} arguments provided, {len(method.params)} expected")
+
         # Check arguments against their type
+        param_names = list(method.params)
+        for i, arg in enumerate(ctx.params):
+            if lookupClass(arg.dataType).conformsTo(lookupClass(method.params[param_names[i]])):
+                continue
+            else:
+                raise badargs1(f"Incorrect argument {arg.getText()} for parameter {param_names[i]}")
 
     def exitAddition(self, ctx: coolParser.AdditionContext):
         left_type = ctx.expr(0).dataType

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from antlr.coolParser import coolParser
 
 from listeners.basicSemanticCheck import basicSemanticListener
 from listeners.structureBuilder import structureBuilder
+from listeners.typeChecker import typeChecker
 
 def compile(file):
     parser = coolParser(CommonTokenStream(coolLexer(FileStream(file))))
@@ -13,7 +14,9 @@ def compile(file):
     
     walker.walk(basicSemanticListener(), tree)
     
-    walker.walk(structureBuilder(), tree)
+    walker.walk(structureBuilder(), tree)  # build the allClasses dict
+
+    walker.walk(typeChecker(), tree)
     
 
 

--- a/resources/semantic/input/badargs1.cool
+++ b/resources/semantic/input/badargs1.cool
@@ -10,4 +10,3 @@ class B inherits A {
       foo(b:B, x:Int) : String { "moo" };
 };
 
-

--- a/test/semantic_three_test.py
+++ b/test/semantic_three_test.py
@@ -8,46 +8,46 @@ def test_assignnoconform():
      with pytest.raises(assignnoconform):
          compile('resources/semantic/input/assignnoconform.cool')
 
-# def test_attrbadinit():
-#      with pytest.raises(attrbadinit):
-#          compile('resources/semantic/input/attrbadinit.cool')
+def test_attrbadinit():
+     with pytest.raises(attrbadinit):
+         compile('resources/semantic/input/attrbadinit.cool')
 
-# def test_attroverride():
-#     with pytest.raises(attroverride):
-#         compile('resources/semantic/input/attroverride.cool')
+def test_attroverride():
+    with pytest.raises(attroverride):
+        compile('resources/semantic/input/attroverride.cool')
 
-# def test_badargs1():
-#     with pytest.raises(badargs1):
-#         compile('resources/semantic/input/badargs1.cool')
+def test_badargs1():
+    with pytest.raises(badargs1):
+        compile('resources/semantic/input/badargs1.cool')
 
-# def test_badmethodcallsitself():
-#     with pytest.raises(badmethodcallsitself):
-#         compile('resources/semantic/input/badmethodcallsitself.cool')
+def test_badmethodcallsitself():
+    with pytest.raises(badmethodcallsitself):
+        compile('resources/semantic/input/badmethodcallsitself.cool')
 
-# def test_badstaticdispatch():
-#     with pytest.raises(badstaticdispatch):
-#         compile('resources/semantic/input/badstaticdispatch.cool')
+def test_badstaticdispatch():
+    with pytest.raises(badstaticdispatch):
+        compile('resources/semantic/input/badstaticdispatch.cool')
 
-# def test_dupformals():
-#     with pytest.raises(dupformals):
-#         compile('resources/semantic/input/dupformals.cool')
+def test_dupformals():
+    with pytest.raises(dupformals):
+        compile('resources/semantic/input/dupformals.cool')
 
-# def test_letbadinit():
-#     with pytest.raises(letbadinit):
-#         compile('resources/semantic/input/letbadinit.cool')
+def test_letbadinit():
+    with pytest.raises(letbadinit):
+        compile('resources/semantic/input/letbadinit.cool')
 
-# def test_lubtest():
-#     with pytest.raises(lubtest):
-#         compile('resources/semantic/input/lubtest.cool')
+def test_lubtest():
+    with pytest.raises(lubtest):
+        compile('resources/semantic/input/lubtest.cool')
 
-# def test_overridingmethod4():
-#     with pytest.raises(overridingmethod4):
-#         compile('resources/semantic/input/overridingmethod4.cool')
+def test_overridingmethod4():
+    with pytest.raises(overridingmethod4):
+        compile('resources/semantic/input/overridingmethod4.cool')
 
-# def test_signaturechange():
-#     with pytest.raises(signaturechange):
-#         compile('resources/semantic/input/signaturechange.cool')
+def test_signaturechange():
+    with pytest.raises(signaturechange):
+        compile('resources/semantic/input/signaturechange.cool')
 
-# def test_trickyatdispatch2():
-#     with pytest.raises(trickyatdispatch2):
-#         compile('resources/semantic/input/trickyatdispatch2.cool')
+def test_trickyatdispatch2():
+    with pytest.raises(trickyatdispatch2):
+        compile('resources/semantic/input/trickyatdispatch2.cool')

--- a/test/semantic_three_test.py
+++ b/test/semantic_three_test.py
@@ -8,25 +8,25 @@ def test_assignnoconform():
      with pytest.raises(assignnoconform):
          compile('resources/semantic/input/assignnoconform.cool')
 
-def test_attrbadinit():
-     with pytest.raises(attrbadinit):
-         compile('resources/semantic/input/attrbadinit.cool')
+# def test_attrbadinit():
+#      with pytest.raises(attrbadinit):
+#          compile('resources/semantic/input/attrbadinit.cool')
 
-def test_attroverride():
-    with pytest.raises(attroverride):
-        compile('resources/semantic/input/attroverride.cool')
+# def test_attroverride():
+#     with pytest.raises(attroverride):
+#         compile('resources/semantic/input/attroverride.cool')
 
 def test_badargs1():
     with pytest.raises(badargs1):
         compile('resources/semantic/input/badargs1.cool')
 
-def test_badmethodcallsitself():
-    with pytest.raises(badmethodcallsitself):
-        compile('resources/semantic/input/badmethodcallsitself.cool')
+# def test_badmethodcallsitself():
+#     with pytest.raises(badmethodcallsitself):
+#         compile('resources/semantic/input/badmethodcallsitself.cool')
 
-def test_badstaticdispatch():
-    with pytest.raises(badstaticdispatch):
-        compile('resources/semantic/input/badstaticdispatch.cool')
+# def test_badstaticdispatch():
+#     with pytest.raises(badstaticdispatch):
+#         compile('resources/semantic/input/badstaticdispatch.cool')
 
 def test_dupformals():
     with pytest.raises(dupformals):
@@ -36,18 +36,18 @@ def test_letbadinit():
     with pytest.raises(letbadinit):
         compile('resources/semantic/input/letbadinit.cool')
 
-def test_lubtest():
-    with pytest.raises(lubtest):
-        compile('resources/semantic/input/lubtest.cool')
+# def test_lubtest():
+#     with pytest.raises(lubtest):
+#         compile('resources/semantic/input/lubtest.cool')
 
-def test_overridingmethod4():
-    with pytest.raises(overridingmethod4):
-        compile('resources/semantic/input/overridingmethod4.cool')
+# def test_overridingmethod4():
+#     with pytest.raises(overridingmethod4):
+#         compile('resources/semantic/input/overridingmethod4.cool')
 
-def test_signaturechange():
-    with pytest.raises(signaturechange):
-        compile('resources/semantic/input/signaturechange.cool')
+# def test_signaturechange():
+#     with pytest.raises(signaturechange):
+#         compile('resources/semantic/input/signaturechange.cool')
 
-def test_trickyatdispatch2():
-    with pytest.raises(trickyatdispatch2):
-        compile('resources/semantic/input/trickyatdispatch2.cool')
+# def test_trickyatdispatch2():
+#     with pytest.raises(trickyatdispatch2):
+#         compile('resources/semantic/input/trickyatdispatch2.cool')

--- a/test/semantic_three_test.py
+++ b/test/semantic_three_test.py
@@ -8,46 +8,46 @@ def test_assignnoconform():
      with pytest.raises(assignnoconform):
          compile('resources/semantic/input/assignnoconform.cool')
 
-def test_attrbadinit():
-     with pytest.raises(attrbadinit):
-         compile('resources/semantic/input/attrbadinit.cool')
+# def test_attrbadinit():
+#      with pytest.raises(attrbadinit):
+#          compile('resources/semantic/input/attrbadinit.cool')
 
-def test_attroverride():
-    with pytest.raises(attroverride):
-        compile('resources/semantic/input/attroverride.cool')
+# def test_attroverride():
+#     with pytest.raises(attroverride):
+#         compile('resources/semantic/input/attroverride.cool')
 
-def test_badargs1():
-    with pytest.raises(badargs1):
-        compile('resources/semantic/input/badargs1.cool')
+# def test_badargs1():
+#     with pytest.raises(badargs1):
+#         compile('resources/semantic/input/badargs1.cool')
 
-def test_badmethodcallsitself():
-    with pytest.raises(badmethodcallsitself):
-        compile('resources/semantic/input/badmethodcallsitself.cool')
+# def test_badmethodcallsitself():
+#     with pytest.raises(badmethodcallsitself):
+#         compile('resources/semantic/input/badmethodcallsitself.cool')
 
-def test_badstaticdispatch():
-    with pytest.raises(badstaticdispatch):
-        compile('resources/semantic/input/badstaticdispatch.cool')
+# def test_badstaticdispatch():
+#     with pytest.raises(badstaticdispatch):
+#         compile('resources/semantic/input/badstaticdispatch.cool')
 
-def test_dupformals():
-    with pytest.raises(dupformals):
-        compile('resources/semantic/input/dupformals.cool')
+# def test_dupformals():
+#     with pytest.raises(dupformals):
+#         compile('resources/semantic/input/dupformals.cool')
 
-def test_letbadinit():
-    with pytest.raises(letbadinit):
-        compile('resources/semantic/input/letbadinit.cool')
+# def test_letbadinit():
+#     with pytest.raises(letbadinit):
+#         compile('resources/semantic/input/letbadinit.cool')
 
-def test_lubtest():
-    with pytest.raises(lubtest):
-        compile('resources/semantic/input/lubtest.cool')
+# def test_lubtest():
+#     with pytest.raises(lubtest):
+#         compile('resources/semantic/input/lubtest.cool')
 
-def test_overridingmethod4():
-    with pytest.raises(overridingmethod4):
-        compile('resources/semantic/input/overridingmethod4.cool')
+# def test_overridingmethod4():
+#     with pytest.raises(overridingmethod4):
+#         compile('resources/semantic/input/overridingmethod4.cool')
 
-def test_signaturechange():
-    with pytest.raises(signaturechange):
-        compile('resources/semantic/input/signaturechange.cool')
+# def test_signaturechange():
+#     with pytest.raises(signaturechange):
+#         compile('resources/semantic/input/signaturechange.cool')
 
-def test_trickyatdispatch2():
-    with pytest.raises(trickyatdispatch2):
-        compile('resources/semantic/input/trickyatdispatch2.cool')
+# def test_trickyatdispatch2():
+#     with pytest.raises(trickyatdispatch2):
+#         compile('resources/semantic/input/trickyatdispatch2.cool')

--- a/test/semantic_three_test.py
+++ b/test/semantic_three_test.py
@@ -4,50 +4,50 @@ from main import dummy
 from main import compile
 from util.exceptions import *
 
-def test_assignnoconform():
-     with pytest.raises(assignnoconform):
-         compile('resources/semantic/input/assignnoconform.cool')
+# def test_assignnoconform():
+#      with pytest.raises(assignnoconform):
+#          compile('resources/semantic/input/assignnoconform.cool')
 
-def test_attrbadinit():
-     with pytest.raises(attrbadinit):
-         compile('resources/semantic/input/attrbadinit.cool')
+# def test_attrbadinit():
+#      with pytest.raises(attrbadinit):
+#          compile('resources/semantic/input/attrbadinit.cool')
 
-def test_attroverride():
-    with pytest.raises(attroverride):
-        compile('resources/semantic/input/attroverride.cool')
+# def test_attroverride():
+#     with pytest.raises(attroverride):
+#         compile('resources/semantic/input/attroverride.cool')
 
 def test_badargs1():
     with pytest.raises(badargs1):
         compile('resources/semantic/input/badargs1.cool')
 
-def test_badmethodcallsitself():
-    with pytest.raises(badmethodcallsitself):
-        compile('resources/semantic/input/badmethodcallsitself.cool')
+# def test_badmethodcallsitself():
+#     with pytest.raises(badmethodcallsitself):
+#         compile('resources/semantic/input/badmethodcallsitself.cool')
 
-def test_badstaticdispatch():
-    with pytest.raises(badstaticdispatch):
-        compile('resources/semantic/input/badstaticdispatch.cool')
+# def test_badstaticdispatch():
+#     with pytest.raises(badstaticdispatch):
+#         compile('resources/semantic/input/badstaticdispatch.cool')
 
-def test_dupformals():
-    with pytest.raises(dupformals):
-        compile('resources/semantic/input/dupformals.cool')
+# def test_dupformals():
+#     with pytest.raises(dupformals):
+#         compile('resources/semantic/input/dupformals.cool')
 
-def test_letbadinit():
-    with pytest.raises(letbadinit):
-        compile('resources/semantic/input/letbadinit.cool')
+# def test_letbadinit():
+#     with pytest.raises(letbadinit):
+#         compile('resources/semantic/input/letbadinit.cool')
 
-def test_lubtest():
-    with pytest.raises(lubtest):
-        compile('resources/semantic/input/lubtest.cool')
+# def test_lubtest():
+#     with pytest.raises(lubtest):
+#         compile('resources/semantic/input/lubtest.cool')
 
-def test_overridingmethod4():
-    with pytest.raises(overridingmethod4):
-        compile('resources/semantic/input/overridingmethod4.cool')
+# def test_overridingmethod4():
+#     with pytest.raises(overridingmethod4):
+#         compile('resources/semantic/input/overridingmethod4.cool')
 
-def test_signaturechange():
-    with pytest.raises(signaturechange):
-        compile('resources/semantic/input/signaturechange.cool')
+# def test_signaturechange():
+#     with pytest.raises(signaturechange):
+#         compile('resources/semantic/input/signaturechange.cool')
 
-def test_trickyatdispatch2():
-    with pytest.raises(trickyatdispatch2):
-        compile('resources/semantic/input/trickyatdispatch2.cool')
+# def test_trickyatdispatch2():
+#     with pytest.raises(trickyatdispatch2):
+#         compile('resources/semantic/input/trickyatdispatch2.cool')

--- a/test/semantic_three_test.py
+++ b/test/semantic_three_test.py
@@ -48,6 +48,6 @@ def test_letbadinit():
 #     with pytest.raises(signaturechange):
 #         compile('resources/semantic/input/signaturechange.cool')
 
-# def test_trickyatdispatch2():
-#     with pytest.raises(trickyatdispatch2):
-#         compile('resources/semantic/input/trickyatdispatch2.cool')
+def test_trickyatdispatch2():
+    with pytest.raises(trickyatdispatch2):
+        compile('resources/semantic/input/trickyatdispatch2.cool')

--- a/test/semantic_three_test.py
+++ b/test/semantic_three_test.py
@@ -4,50 +4,50 @@ from main import dummy
 from main import compile
 from util.exceptions import *
 
-# def test_assignnoconform():
-#      with pytest.raises(assignnoconform):
-#          compile('resources/semantic/input/assignnoconform.cool')
+def test_assignnoconform():
+     with pytest.raises(assignnoconform):
+         compile('resources/semantic/input/assignnoconform.cool')
 
-# def test_attrbadinit():
-#      with pytest.raises(attrbadinit):
-#          compile('resources/semantic/input/attrbadinit.cool')
+def test_attrbadinit():
+     with pytest.raises(attrbadinit):
+         compile('resources/semantic/input/attrbadinit.cool')
 
-# def test_attroverride():
-#     with pytest.raises(attroverride):
-#         compile('resources/semantic/input/attroverride.cool')
+def test_attroverride():
+    with pytest.raises(attroverride):
+        compile('resources/semantic/input/attroverride.cool')
 
 def test_badargs1():
     with pytest.raises(badargs1):
         compile('resources/semantic/input/badargs1.cool')
 
-# def test_badmethodcallsitself():
-#     with pytest.raises(badmethodcallsitself):
-#         compile('resources/semantic/input/badmethodcallsitself.cool')
+def test_badmethodcallsitself():
+    with pytest.raises(badmethodcallsitself):
+        compile('resources/semantic/input/badmethodcallsitself.cool')
 
-# def test_badstaticdispatch():
-#     with pytest.raises(badstaticdispatch):
-#         compile('resources/semantic/input/badstaticdispatch.cool')
+def test_badstaticdispatch():
+    with pytest.raises(badstaticdispatch):
+        compile('resources/semantic/input/badstaticdispatch.cool')
 
-# def test_dupformals():
-#     with pytest.raises(dupformals):
-#         compile('resources/semantic/input/dupformals.cool')
+def test_dupformals():
+    with pytest.raises(dupformals):
+        compile('resources/semantic/input/dupformals.cool')
 
-# def test_letbadinit():
-#     with pytest.raises(letbadinit):
-#         compile('resources/semantic/input/letbadinit.cool')
+def test_letbadinit():
+    with pytest.raises(letbadinit):
+        compile('resources/semantic/input/letbadinit.cool')
 
-# def test_lubtest():
-#     with pytest.raises(lubtest):
-#         compile('resources/semantic/input/lubtest.cool')
+def test_lubtest():
+    with pytest.raises(lubtest):
+        compile('resources/semantic/input/lubtest.cool')
 
-# def test_overridingmethod4():
-#     with pytest.raises(overridingmethod4):
-#         compile('resources/semantic/input/overridingmethod4.cool')
+def test_overridingmethod4():
+    with pytest.raises(overridingmethod4):
+        compile('resources/semantic/input/overridingmethod4.cool')
 
-# def test_signaturechange():
-#     with pytest.raises(signaturechange):
-#         compile('resources/semantic/input/signaturechange.cool')
+def test_signaturechange():
+    with pytest.raises(signaturechange):
+        compile('resources/semantic/input/signaturechange.cool')
 
-# def test_trickyatdispatch2():
-#     with pytest.raises(trickyatdispatch2):
-#         compile('resources/semantic/input/trickyatdispatch2.cool')
+def test_trickyatdispatch2():
+    with pytest.raises(trickyatdispatch2):
+        compile('resources/semantic/input/trickyatdispatch2.cool')


### PR DESCRIPTION
Refactor `structureBuilder` and create `typeChecker`.

- Defined class names are collected first by structureBuilder
- typeChecker can then perform any type checkings knowing that all necessary classes have been added to `classDict`